### PR TITLE
Syncing Python repository with redis-challenge-repo-syncer

### DIFF
--- a/codecrafters.yml
+++ b/codecrafters.yml
@@ -16,3 +16,4 @@ debug: false
 #
 # Available versions: python-3.7, python-3.8
 language_pack: python-3.8
+


### PR DESCRIPTION
This repository is maintained via https://github.com/rohitpaulk/redis-challenge-repo-syncer.